### PR TITLE
:bug: Fixed skips re-matching with the root node

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,5 +20,11 @@
     </plugins>
   </build>
   <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.11.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/src/com/sperske/jason/flashtext/KeywordProcessor.java
+++ b/src/com/sperske/jason/flashtext/KeywordProcessor.java
@@ -191,12 +191,21 @@ public class KeywordProcessor {
 				if (node != null) {
 					buffer.append(c);
 					currentNode = node;
+					return;
+				}
+
+				String keyword = currentNode.get();
+				out.append(keyword != null ? keyword : buffer);
+				buffer = new StringBuffer();
+				currentNode = this.rootNode;
+
+				// re-match root node
+				node = this.rootNode.get(match_c);
+				if (node != null) {
+					buffer.append(c);
+					currentNode = node;
 				} else {
-					String keyword = currentNode.get();
-					out.append(keyword != null ? keyword : buffer);
 					out.append(c);
-					buffer = new StringBuffer();
-					currentNode = this.rootNode;
 				}
 			};
 		}

--- a/test/com/sperske/jason/flashtext/KeywordReplacerTests.java
+++ b/test/com/sperske/jason/flashtext/KeywordReplacerTests.java
@@ -52,4 +52,12 @@ class KeywordReplacerTests {
 		assertTrue(keywords.contains("python"));
 		assertTrue(keywords.contains("java"));
 	}
+	@Test
+	void shouldReplaceIfFirstMatchFails() {
+		KeywordProcessor processor = new KeywordProcessor();
+		processor.addKeyword("ab", "12");
+		processor.addKeyword("cd", "34");
+
+		assertEquals("a34", processor.replace("acd"));
+	}
 }


### PR DESCRIPTION
If a character in the middle of a match fails to match, instead of attempting to match the root node with that character, it is directly skipped
```java
KeywordProcessor k = new KeywordProcessor();
k.addKeyword("ab", "12");
k.addKeyword("cd", "34");
System.out.println(k.replace("acd")); // before fix: "acd"  after: "a34"
```
@jasonsperske 