### PR TITLE
:bug: Fixed replace/extract bug

### DIFF
--- a/src/com/sperske/jason/flashtext/KeywordTrieNode.java
+++ b/src/com/sperske/jason/flashtext/KeywordTrieNode.java
@@ -68,7 +68,15 @@ public class KeywordTrieNode {
 		}
 		return this;
 	}
-	
+
+	public String getKeyword() {
+		return keyword;
+	}
+
+	public String getCleanName() {
+		return clean_name;
+	}
+
 	@Override
 	public String toString() {
 		return toIndentedString("");

--- a/test/com/sperske/jason/flashtext/KeywordReplacerTests.java
+++ b/test/com/sperske/jason/flashtext/KeywordReplacerTests.java
@@ -1,6 +1,8 @@
 package com.sperske.jason.flashtext;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
@@ -59,5 +61,18 @@ class KeywordReplacerTests {
 		processor.addKeyword("cd", "34");
 
 		assertEquals("a34", processor.replace("acd"));
+	}
+
+	@Test
+	void shouldReplaceAndExtractInTheMiddleOfSentence() {
+		KeywordProcessor processor = new KeywordProcessor();
+		processor.addKeyword("abc", "123");
+		processor.addKeyword("bd", "24");
+
+		Set<String> keywords = processor.extractKeywords("abd");
+        assertEquals(1, keywords.size());
+		assertTrue(keywords.contains("24"));
+
+		assertEquals("a24", processor.replace("abd"));
 	}
 }


### PR DESCRIPTION
When performing a replacement with the mapping {"abc" -> "123", "bd" -> "24"}, the input string "abd" should be replaced to "a24", but the replacement fails to occur as expected.

```java
KeywordProcessor k = new KeywordProcessor();
k.addKeyword("abc", "123");
k.addKeyword("bd", "24");
System.out.println(k.replace("abd")); // before fix: "abd"  after: "a24"
```
@jasonsperske 